### PR TITLE
Boiler Placement Crash Fix

### DIFF
--- a/src/main/java/com/JAWolfe/terrafirmapunktweaks/handlers/PlayerInteractionHandler.java
+++ b/src/main/java/com/JAWolfe/terrafirmapunktweaks/handlers/PlayerInteractionHandler.java
@@ -99,12 +99,12 @@ public class PlayerInteractionHandler
 		{
 			if(Loader.isModLoaded("Steamcraft"))
 			{
-				if(event.entityPlayer.getCurrentEquippedItem().getItem() == Item.getItemFromBlock(SteamcraftBlocks.boiler) && ConfigSettings.FSPBoilerWaterFix)
+				if(itemInHand.getItem() == Item.getItemFromBlock(SteamcraftBlocks.boiler) && ConfigSettings.FSPBoilerWaterFix)
 				{
 					event.setCanceled(true);
 					handleBlockPlacement(event.entityPlayer, event.entityLiving, event.world, TFPBlocks.tweakedboiler, event.x, event.y, event.z, event.face);
 				}			
-				else if(event.entityPlayer.getCurrentEquippedItem().getItem() == Item.getItemFromBlock(SteamcraftBlocks.flashBoiler) && ConfigSettings.FSPFlashBoilerWaterFix)
+				else if(itemInHand.getItem() == Item.getItemFromBlock(SteamcraftBlocks.flashBoiler) && ConfigSettings.FSPFlashBoilerWaterFix)
 				{
 					event.setCanceled(true);
 					switch(event.face)
@@ -118,21 +118,21 @@ public class PlayerInteractionHandler
 						default: break;
 					}			
 					
-					if(event.entityPlayer.getCurrentEquippedItem().stackSize == 1)
+					if(itemInHand.stackSize == 1)
 						event.entityPlayer.setCurrentItemOrArmor(0, null);
 					else
-						event.entityPlayer.getCurrentEquippedItem().stackSize--;
+						itemInHand.stackSize--;
 				}
 			}
 			
-			if(event.entityPlayer.getCurrentEquippedItem().getItem() == Item.getItemFromBlock(Blocks.chest))
+			if(itemInHand.getItem() == Item.getItemFromBlock(Blocks.chest))
 			{
 				event.setCanceled(true);
 
-				if(event.entityPlayer.getCurrentEquippedItem().stackSize == 1)
+				if(itemInHand.stackSize == 1)
 					event.entityPlayer.setCurrentItemOrArmor(0, null);
 				else
-					event.entityPlayer.getCurrentEquippedItem().stackSize--;
+					itemInHand.stackSize--;
 			}
 		}
 	}


### PR DESCRIPTION
# Why did it crash?

event.entityPlayer.getCurrentEquippedItem() returned null after we placed all parts of the boiler(if there were no more boiler-block items)

Then we try to event.entityPlayer.getCurrentEquippedItem().getItem() in the chest-placement part, resulting in NullPointerException

# Why does this improve stuff?

By using the itemInHand we prepared before boiler placement we will not get any errors

# Why do I necropost?

For any souls unfortunate enough to try to host TerraFirmaPunk for their friends